### PR TITLE
Remove competing animation loops

### DIFF
--- a/draw.js
+++ b/draw.js
@@ -31,15 +31,14 @@ function draw() {
 
     before = after;
 
-    d3.timer(draw, 100);
     return true;
 }
 
-draw();
-
-Leap.loop(controllerOptions, function(frame) {
+Leap.loop(controllerOptions, function(frame, done) {
     after = {};
     for (var i = 0; i < frame.pointables.length; i++) {
         after[frame.pointables[i].id] = frame.pointables[i];
     }
+    draw();
+    done();
 });

--- a/draw.js
+++ b/draw.js
@@ -30,8 +30,6 @@ function draw() {
     }
 
     before = after;
-
-    return true;
 }
 
 Leap.loop(controllerOptions, function(frame, done) {

--- a/gesture.js
+++ b/gesture.js
@@ -35,13 +35,10 @@ function draw() {
     vector[0] *= 0.9;
     vector[1] *= 0.9;
 
-    d3.timer(draw, 10);
     return true;
 }
 
-draw();
-
-Leap.loop(controllerOptions, function(frame) {
+Leap.loop(controllerOptions, function(frame, done) {
     if (frame.gestures.length > 0) {
         for (var i = 0; i < frame.gestures.length; i++) {
             var gesture = frame.gestures[i];
@@ -53,4 +50,6 @@ Leap.loop(controllerOptions, function(frame) {
             }
         }
     }
+    draw();
+    done();
 });

--- a/gesture.js
+++ b/gesture.js
@@ -34,8 +34,6 @@ function draw() {
     // slow down the movement of the ball
     vector[0] *= 0.9;
     vector[1] *= 0.9;
-
-    return true;
 }
 
 Leap.loop(controllerOptions, function(frame, done) {

--- a/pointer.js
+++ b/pointer.js
@@ -26,7 +26,6 @@ function draw() {
     balls.attr('transform', function(d) {
         return 'translate(' + [d.tipPosition.x, -d.tipPosition.y] + ')';
     });
-    return true;
 }
 
 Leap.loop(controllerOptions, function(frame, done) {

--- a/pointer.js
+++ b/pointer.js
@@ -26,12 +26,11 @@ function draw() {
     balls.attr('transform', function(d) {
         return 'translate(' + [d.tipPosition.x, -d.tipPosition.y] + ')';
     });
-    d3.timer(draw, 100);
     return true;
 }
 
-draw();
-
-Leap.loop(controllerOptions, function(frame) {
+Leap.loop(controllerOptions, function(frame, done) {
     fingers = frame.pointables;
+    draw();
+    done();
 });


### PR DESCRIPTION
In Chrome, d3.timer and Leap.loop were running competing animation loops.

I changed it to use Leap's done() to wait to run the next frame after drawing, so there's only one loop running. Should be much smoother.
